### PR TITLE
Add Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,30 @@
 buildscript {
     dependencies {
         classpath group: 'de.dynamicfiles.projects.gradle.plugins', name: 'javafx-gradle-plugin', version: '8.7.0'
-
+        classpath group: 'com.layer', name: 'gradle-git-repo-plugin', version: '2.0.2'
     }
     repositories {
         jcenter()
+        mavenCentral()
     }
 
 }
 apply plugin: 'java'
 apply plugin: 'javafx-gradle-plugin'
+apply plugin: 'git-repo'
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
 
     // https://mvnrepository.com/artifact/org.apache.derby/derby
     compile group: 'org.apache.derby', name: 'derby', version: '10.13.1.1'
+    //compile 'com.github.dejv78.jfx.radialmenu:radialmenu:1.0.1'
 }
 
 repositories {
     jcenter()
+    mavenCentral()
+    git("https://github.com/dejv78/jfx.radialmenu.git", "radialmenu", "master", "releases")
 }
 
 jfx {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/org.apache.derby/derby
     compile group: 'org.apache.derby', name: 'derby', version: '10.13.1.1'
-    //compile 'com.github.dejv78.jfx.radialmenu:radialmenu:1.0.1'
 }
 
 repositories {


### PR DESCRIPTION
Added dependancy to the radial menu library to build.gradle. 
Documentation and examples are given on his site below. Licensing is also available.
https://dejv78.github.io/news/radialmenu-version-1.0.1-released/